### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,6 @@ description: A type-safe, object-oriented option parser using the mapping-patter
 authors:
   - Stefan Merettig <stefan-merettig@nuriaproject.org>
 
-crystal: 0.24.1
+crystal: 1.0.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,6 @@ description: A type-safe, object-oriented option parser using the mapping-patter
 authors:
   - Stefan Merettig <stefan-merettig@nuriaproject.org>
 
-crystal: 1.0.0
+crystal: ">= 0.24.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on `shards install`

```
- `crystal (~> 0.24, >= 0.24.1)` required by `toka 0.1.2`
```